### PR TITLE
Anpassung an neue Bungee API

### DIFF
--- a/src/com/github/calenria/scbungee/SimpleChat.java
+++ b/src/com/github/calenria/scbungee/SimpleChat.java
@@ -11,11 +11,9 @@ import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
 import net.md_5.bungee.BungeeCord;
-import net.md_5.bungee.Logger;
 import net.md_5.bungee.api.plugin.Plugin;
 
 public class SimpleChat extends Plugin {
-    private static Logger        log          = Logger.$();
     public static ResourceBundle messages     = null;
     public static String         pluginPath   = "./plugins/SimpleChat-Bungee/";
     public File                  messagesFile = new File(pluginPath + "messages.properties");
@@ -37,7 +35,7 @@ public class SimpleChat extends Plugin {
                 out.newLine();
                 out.close();
             } catch (Exception ex) {
-                log.warning(ex.getLocalizedMessage());
+                BungeeCord.getInstance().getLogger().warning(ex.getLocalizedMessage());
             }
         }
 
@@ -63,7 +61,7 @@ public class SimpleChat extends Plugin {
                 out.newLine();
                 out.close();
             } catch (Exception e) {
-                log.warning(e.getLocalizedMessage());
+                BungeeCord.getInstance().getLogger().warning(e.getLocalizedMessage());
             }
         }
         try {

--- a/src/com/github/calenria/scbungee/SimpleChatListener.java
+++ b/src/com/github/calenria/scbungee/SimpleChatListener.java
@@ -7,7 +7,6 @@ import java.util.Map.Entry;
 import java.util.StringTokenizer;
 
 import net.md_5.bungee.BungeeCord;
-import net.md_5.bungee.Logger;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -21,14 +20,12 @@ import com.google.common.eventbus.Subscribe;
 
 public class SimpleChatListener implements Listener {
 
-    private static Logger log = Logger.$();
-
     @Subscribe
     public void onLogin(LoginEvent event) {
         if (SimpleChat.hideStream) {
             return;
         }
-        log.info("Player Login: " + event.getConnection().getName());
+        BungeeCord.getInstance().getLogger().info("Player Login: " + event.getConnection().getName());
         sendAll(ChatColor.translateAlternateColorCodes('&', String.format(SimpleChat.messages.getString("login"), event.getConnection().getName())));
     }
 
@@ -37,7 +34,7 @@ public class SimpleChatListener implements Listener {
         if (SimpleChat.hideStream) {
             return;
         }
-        log.info("Player Disconnect: " + event.getPlayer().getName());
+        BungeeCord.getInstance().getLogger().info("Player Disconnect: " + event.getPlayer().getName());
         sendAll(ChatColor.translateAlternateColorCodes('&', String.format(SimpleChat.messages.getString("logout"), event.getPlayer().getName())));
     }
 
@@ -45,7 +42,7 @@ public class SimpleChatListener implements Listener {
     public void onPluginMessage(PluginMessageEvent event) {
         String pluginMessage = new String(event.getData());
         if (SimpleChat.debug) {
-            log.info("Recived plugin message: " + pluginMessage);
+        	BungeeCord.getInstance().getLogger().info("Recived plugin message: " + pluginMessage);
         }
         if (!event.getTag().equals("SimpleChat"))
             return;
@@ -113,20 +110,20 @@ public class SimpleChatListener implements Listener {
 
     private void sendPluginMessage(String pluginMessage, Entry<String, ServerInfo> server) {
         if (SimpleChat.debug) {
-            log.info("[perUser] Sending Message to: " + server.getKey());
+        	BungeeCord.getInstance().getLogger().info("[perUser] Sending Message to: " + server.getKey());
         }
         List<ProxiedPlayer> pPlayers = new ArrayList<ProxiedPlayer>(server.getValue().getPlayers());
         if (!pPlayers.isEmpty()) {
             ProxiedPlayer pPlayer = pPlayers.get(0);
             pPlayer.sendData("SimpleChat", pluginMessage.getBytes());
         } else {
-            log.info("No Player found on Server: " + server.getKey());
+        	BungeeCord.getInstance().getLogger().info("No Player found on Server: " + server.getKey());
         }
     }
 
     private void sendPluginMessage(String pluginMessage, Server server) {
         if (SimpleChat.debug) {
-            log.info("[perServer] Sending Message to: " + server.getInfo().getName());
+        	BungeeCord.getInstance().getLogger().info("[perServer] Sending Message to: " + server.getInfo().getName());
         }
         server.sendData("SimpleChat", pluginMessage.getBytes());
     }
@@ -136,7 +133,7 @@ public class SimpleChatListener implements Listener {
         if (!pPlayers.isEmpty()) {
             for (ProxiedPlayer proxiedPlayer : pPlayers) {
                 if (SimpleChat.debug) {
-                    log.info("Sending Message to: " + proxiedPlayer.getName());
+                	BungeeCord.getInstance().getLogger().info("Sending Message to: " + proxiedPlayer.getName());
                 }
                 proxiedPlayer.sendMessage(msg);
             }


### PR DESCRIPTION
Ein Freund hatte ein Problem nach dem Update von BungeeCord. Es stellte sich heraus, dass eine Klasse namens net.md_5.bungee.Logger nicht mehr vorhanden war und wohl in net.md_5.bungee.BungeeLogger umbenannt worden ist. Jedenfalls lief das Plugin nach ein paar Handgriffen wieder, allerdings programmiere ich nicht an Minecraftprojekten, also ist Obacht angesagt :D

Gruß,
exit91
